### PR TITLE
feat: Add support symfony ^6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 1.0.0
++ Add support php ^8.0
++ Add support symfony ^6.0
+
+---
+
+# DEPRECATED
+
+> Use ^1.0.0
+
 ## 5.2.12
 + Added built-in transport and buses for communication between services
 + Added `BroadcastingBus` to dispatch message to external services

--- a/composer.json
+++ b/composer.json
@@ -18,16 +18,16 @@
         "liip/monitor-bundle": "^2.16",
         "pagerfanta/pagerfanta": "^3.0",
         "symfony-bundles/json-request-bundle": "^4.0",
-        "symfony/framework-bundle": "^5.2",
-        "symfony/messenger": "^5.2",
-        "symfony/translation": "^5.2",
-        "symfony/validator": "^5.2"
+        "symfony/framework-bundle": "^5.2 || ^6.0",
+        "symfony/messenger": "^5.2 || ^6.0",
+        "symfony/translation": "^5.2 || ^6.0",
+        "symfony/validator": "^5.2 || ^6.0"
     },
     "require-dev": {
         "haydenpierce/class-finder": "^0.4.0",
         "phpunit/phpunit": "^9.5",
         "roave/security-advisories": "dev-master",
-        "symfony/maker-bundle": "^1.29"
+        "symfony/maker-bundle": "^1.31"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
* Deprecate old versions. Use new ^1.0.0 version of bundle
* Update symfony/maker-bundle version (security advisories)

RND-225

Signed-off-by: Maxim Petrovich <m.petrovich@lerna.tech>