### PR TITLE
feat: Deprecate AbstractCommand and AbstractQuery classes

### DIFF
--- a/Command/Maker/MakeUseCaseCommand.php
+++ b/Command/Maker/MakeUseCaseCommand.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace ArtoxLab\Bundle\ClarcBundle\Command\Maker;
 
-use ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Commands\AbstractCommand;
 use ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Commands\AbstractInteractor;
 use ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Interfaces\PaginatorInterface;
 use Exception;
@@ -65,7 +64,6 @@ class MakeUseCaseCommand extends AbstractMaker
      */
     public function configureDependencies(DependencyBuilder $dependencies): void
     {
-        $dependencies->addClassDependency(AbstractCommand::class, 'clarc-bundle');
         $dependencies->addClassDependency(AbstractInteractor::class, 'clarc-bundle');
         $dependencies->addClassDependency(PaginatorInterface::class, 'clarc-bundle');
     }

--- a/Command/Maker/MakeUseCaseQuery.php
+++ b/Command/Maker/MakeUseCaseQuery.php
@@ -11,7 +11,6 @@ namespace ArtoxLab\Bundle\ClarcBundle\Command\Maker;
 
 use ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Commands\AbstractInteractor;
 use ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Interfaces\PaginatorInterface;
-use ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Queries\AbstractQuery;
 use Exception;
 use HaydenPierce\ClassFinder\ClassFinder;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
@@ -68,7 +67,6 @@ class MakeUseCaseQuery extends AbstractMaker
      */
     public function configureDependencies(DependencyBuilder $dependencies): void
     {
-        $dependencies->addClassDependency(AbstractQuery::class, 'clarc-bundle');
         $dependencies->addClassDependency(AbstractInteractor::class, 'clarc-bundle');
         $dependencies->addClassDependency(PaginatorInterface::class, 'clarc-bundle');
     }

--- a/Core/Interfaces/Bus/CommandBus/CommandBus.php
+++ b/Core/Interfaces/Bus/CommandBus/CommandBus.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 namespace ArtoxLab\Bundle\ClarcBundle\Core\Interfaces\Bus\CommandBus;
 
-use ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Commands\AbstractCommand;
 use Symfony\Component\Messenger\HandleTrait;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -31,11 +30,11 @@ class CommandBus implements CommandBusInterface
     /**
      * Executing command
      *
-     * @param AbstractCommand $command Command
+     * @param object $command Command
      *
      * @return mixed The handler returned value
      */
-    public function execute(AbstractCommand $command)
+    public function execute(object $command)
     {
         return $this->handle($command);
     }

--- a/Core/Interfaces/Bus/CommandBus/CommandBusInterface.php
+++ b/Core/Interfaces/Bus/CommandBus/CommandBusInterface.php
@@ -10,18 +10,16 @@ declare(strict_types=1);
 
 namespace ArtoxLab\Bundle\ClarcBundle\Core\Interfaces\Bus\CommandBus;
 
-use ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Commands\AbstractCommand;
-
 interface CommandBusInterface
 {
 
     /**
      * Executing command
      *
-     * @param AbstractCommand $command Command
+     * @param object $command Command
      *
      * @return mixed The handler returned value
      */
-    public function execute(AbstractCommand $command);
+    public function execute(object $command);
 
 }

--- a/Core/Interfaces/Bus/QueryBus/QueryBus.php
+++ b/Core/Interfaces/Bus/QueryBus/QueryBus.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 namespace ArtoxLab\Bundle\ClarcBundle\Core\Interfaces\Bus\QueryBus;
 
-use ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Queries\AbstractQuery;
 use Symfony\Component\Messenger\HandleTrait;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -31,11 +30,11 @@ class QueryBus implements QueryBusInterface
     /**
      * Executing query command
      *
-     * @param AbstractQuery $query Query
+     * @param object $query Query
      *
      * @return mixed The handler returned value
      */
-    public function query(AbstractQuery $query)
+    public function query(object $query)
     {
         return $this->handle($query);
     }

--- a/Core/Interfaces/Bus/QueryBus/QueryBusInterface.php
+++ b/Core/Interfaces/Bus/QueryBus/QueryBusInterface.php
@@ -10,18 +10,16 @@ declare(strict_types=1);
 
 namespace ArtoxLab\Bundle\ClarcBundle\Core\Interfaces\Bus\QueryBus;
 
-use ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Queries\AbstractQuery;
-
 interface QueryBusInterface
 {
 
     /**
      * Executing query command
      *
-     * @param AbstractQuery $query Query
+     * @param object $query Query
      *
      * @return mixed The handler returned value
      */
-    public function query(AbstractQuery $query);
+    public function query(object $query);
 
 }

--- a/Core/UseCases/Commands/AbstractCommand.php
+++ b/Core/UseCases/Commands/AbstractCommand.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Commands;
 
+/**
+ * @deprecated Use pure class
+ */
 class AbstractCommand
 {
 

--- a/Core/UseCases/Queries/AbstractQuery.php
+++ b/Core/UseCases/Queries/AbstractQuery.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Queries;
 
+/**
+ * @deprecated use pure class
+ */
 abstract class AbstractQuery
 {
 

--- a/Core/UseCases/Queries/User/FindAllPermissions/Command.php
+++ b/Core/UseCases/Queries/User/FindAllPermissions/Command.php
@@ -7,8 +7,6 @@
 
 namespace ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Queries\User\FindAllPermissions;
 
-use ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Queries\AbstractQuery;
-
-class Command extends AbstractQuery
+class Command
 {
 }

--- a/Core/UseCases/Queries/User/Navigation/FindAll/Command.php
+++ b/Core/UseCases/Queries/User/Navigation/FindAll/Command.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Queries\User\Navigation\FindAll;
 
-use ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Queries\AbstractQuery;
-
-class Command extends AbstractQuery
+class Command
 {
 
 }

--- a/DependencyInjection/ArtoxLabClarcExtension.php
+++ b/DependencyInjection/ArtoxLabClarcExtension.php
@@ -10,8 +10,6 @@ declare(strict_types=1);
 
 namespace ArtoxLab\Bundle\ClarcBundle\DependencyInjection;
 
-use ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Commands\AbstractCommand;
-use ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Queries\AbstractQuery;
 use Exception;
 use InvalidArgumentException;
 use Symfony\Component\Config\FileLocator;
@@ -71,11 +69,6 @@ class ArtoxLabClarcExtension extends Extension implements PrependExtensionInterf
                             'artox_lab_clarc.messenger.middleware.add_amqp_routing_key',
                         ],
                     ],
-                ],
-                'transports' => ['sync' => 'sync://'],
-                'routing'     => [
-                    AbstractCommand::class => 'sync',
-                    AbstractQuery::class   => 'sync',
                 ],
             ],
         ];

--- a/Resources/skeleton/UseCases/Commands/Command.tpl.php
+++ b/Resources/skeleton/UseCases/Commands/Command.tpl.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 namespace <?= $namespace; ?>;
 
-use ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Commands\AbstractCommand;
-
-class <?= $class_name ?> extends AbstractCommand
+class <?= $class_name ?>
 {
 
 }

--- a/Resources/skeleton/UseCases/Queries/Find/Command.tpl.php
+++ b/Resources/skeleton/UseCases/Queries/Find/Command.tpl.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 namespace <?= $namespace; ?>;
 
-use ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Queries\AbstractQuery;
-
-class <?= $class_name ?> extends AbstractQuery
+class <?= $class_name ?>
 {
 
 }

--- a/Resources/skeleton/UseCases/Queries/List/Command.tpl.php
+++ b/Resources/skeleton/UseCases/Queries/List/Command.tpl.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 namespace <?= $namespace; ?>;
 
-use ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Queries\AbstractQuery;
-
-class <?= $class_name ?> extends AbstractQuery
+class <?= $class_name ?>
 {
 
 }

--- a/Resources/skeleton/UseCases/Queries/Paginate/Command.tpl.php
+++ b/Resources/skeleton/UseCases/Queries/Paginate/Command.tpl.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 namespace <?= $namespace; ?>;
 
-use ArtoxLab\Bundle\ClarcBundle\Core\UseCases\Queries\AbstractQuery;
-
-class <?= $class_name ?> extends AbstractQuery
+class <?= $class_name ?>
 {
 
 }


### PR DESCRIPTION
* Remove dependency on Abstract classes in CommandBus and QueryBus

RND-279

Signed-off-by: Maxim Petrovich <m.petrovich@lerna.tech>